### PR TITLE
Added `prisma` postinstall script as Vercel workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Was getting a build error due to Vercel's dependency caching.  Prisma shared this workaround:

https://www.prisma.io/docs/guides/other/troubleshooting-orm/help-articles/vercel-caching-issue